### PR TITLE
refactor: name change after MongoDB refactoring

### DIFF
--- a/desc.zh.hocon
+++ b/desc.zh.hocon
@@ -4070,7 +4070,7 @@ timeout.label:
 
 }
 
-emqx_connector_mongo {
+emqx_mongodb {
 
 auth_source.desc:
 """与用户证书关联的数据库名称。"""
@@ -4956,7 +4956,7 @@ payload.label:
 
 }
 
-emqx_ee_bridge_mongodb {
+emqx_bridge_mongodb {
 
 collection.desc:
 """数据将被存储到的集合"""


### PR DESCRIPTION
Some modules changed name after MongoDB refactoring in the main repository:

https://github.com/emqx/emqx/pull/10667

This PR reflect these changes.